### PR TITLE
Adding strict dependency annotation.

### DIFF
--- a/lib/javascriptbuilder.js
+++ b/lib/javascriptbuilder.js
@@ -11,11 +11,11 @@ JavascriptBuilder.prototype._getInitFunction = function() {
 
         var myAppDev = angular.module('httpBackendMock', ['ngMockE2E']);
 
-        myAppDev.run(function($httpBackend) {
+        myAppDev.run(['$httpBackend', function($httpBackend) {
             window.httpBackendContext = $httpBackend;
             window.httpBackendContext.context = {};
             var firstSync;
-        });
+        }]);
     };
 
     return initFunction;


### PR DESCRIPTION
`httpbackend` currently throws an error when running against an app
where `ng-strict-di` is used. This fixes that.